### PR TITLE
macos: allow file picker

### DIFF
--- a/lib/misc.dart
+++ b/lib/misc.dart
@@ -14,7 +14,7 @@ class PlatformInfo {
   }
 
   static bool get isAppOS {
-    return Platform.isMacOS || Platform.isAndroid;
+    return Platform.isIOS || Platform.isAndroid;
   }
 }
 

--- a/macos/Runner/DebugProfile.entitlements
+++ b/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>keychain-access-groups</key>
+	<array/>
 </dict>
 </plist>


### PR DESCRIPTION
Hello, I've been trying to run the app in macos and needed to change these files to do it (I also had to add a signing certificate to the project, which is obviously out of scope of this PR). 

The changes in `lib/misc.dart` for sure appear to be a bug/typo. It doesn't seem like iOS/macos is a priority for the repo (as there is no mention about them in the README), so perhaps only that change can be merged.

I also tested iOS and I don't recall changing anything in particular to make it work :), haven't tested the app thoroughly yet, just the basic stuff.

Thanks!